### PR TITLE
fix: run `npm audit fix --force` as best-effort only.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ npx npm-check-updates -u -t ${TARGET_VERSION}
 
 if [ "${PACKAGE_MANAGER}" == 'npm' ]; then
   npm i --package-lock-only
-  npm audit fix --force
+  npm audit fix --force --audit-level=none  # Best effort only
 elif [ "${PACKAGE_MANAGER}" == 'yarn' ]; then
   yarn install
 else


### PR DESCRIPTION
`npm@8` seemed to have changed the exit code of `npm audit fix --force`. Updating to match previous behaviour.

Confirmed exit code changes with use of `--audit-level=none`.