### PR TITLE
fix!: don't run `npm audit`.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,6 @@ npx npm-check-updates -u -t ${TARGET_VERSION}
 
 if [ "${PACKAGE_MANAGER}" == 'npm' ]; then
   npm i --package-lock-only
-  npm audit fix --force --audit-level=none  # Best effort only
 elif [ "${PACKAGE_MANAGER}" == 'yarn' ]; then
   yarn install
 else


### PR DESCRIPTION
* `npm` 7+ is reverting package versions if `npm audit --fix` doesn't work (https://github.com/npm/cli/issues/3708)
* `npm audit` can collide with `.ncurc` rules
* There is no `yarn` equivalent

Removing `npm audit` resolves all these concerns. Repositories can rely on dependabot for transient deps.